### PR TITLE
Update frame.dart

### DIFF
--- a/lib/frame.dart
+++ b/lib/frame.dart
@@ -1,3 +1,5 @@
+library stompdart.frame;
+
 import 'dart:convert';
 
 const String STOMP_EOF = '\x00';


### PR DESCRIPTION
Fix: The imported libraries 'sockjsadapter.dart' and 'frame.dart' should not have the same name '' 
This error makes impossible to use Frame and StompAdapter classes together, then you import it like
import 'package:stompdart/sockjsadapter.dart' as StompAdapter;
import 'package:stompdart/frame.dart' as Frame;
